### PR TITLE
feat: add flags for including non-security and mail-enabled groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ There is no hard depth limit, but **caution** has to be exercised when using thi
 
 It it advised to first run `--query-graph-only` and `--save-graph-response-json results.json` parameters together in order to inspect the groups discovered during the deep search. And only continue with sync if results are below the maximum number of groups SCIM endpoint supports!
 
+## Group types
+
+By default only ["Security Groups"](https://learn.microsoft.com/en-us/graph/api/resources/groups-overview?view=graph-rest-1.0&tabs=http#security-groups-and-mail-enabled-security-groups) will be included in the sync.
+This decision was made in order to [limit the number of groups included in the synchronisation](https://github.com/grusin-db/uc-azure-account-scim-sync-py/issues/9).
+[Other groups types](https://learn.microsoft.com/en-us/graph/api/resources/groups-overview?view=graph-rest-1.0&tabs=http#group-types-in-microsoft-entra-id-and-microsoft-graph) can be included using the `--include-non-security-groups` and `--include-mail-enabled-groups` flags.
+
 ## Incremental synchronization (default)
 
 Uses [Graph API change feed](https://learn.microsoft.com/en-us/graph/api/resources/change-notifications-api-overview?view=graph-rest-1.0) to determine the [groups that have changed](https://learn.microsoft.com/en-us/graph/api/group-delta?view=graph-rest-1.0&tabs=http#query-parameters) since last run. In this mode, all previously synchronized groups will be checked for changes. That means that groups that changed in AAD/Entra, but never were requested to be synced will be ignored.
@@ -127,6 +133,10 @@ Options:
   --full-sync                     synchronizes all groups defined in `groups-
                                   json-file` instead of using graph api change
                                   feed
+  --include-non-security-groups   include non-security Entra groups in the
+                                  sync  [default: False]
+  --include-mail-enabled-groups   include mail-enabled Entra groups in the
+                                  sync  [default: False]                                  
   --help                          Show this message and exit.
 ```
 

--- a/azure_dbr_scim_sync/cli.py
+++ b/azure_dbr_scim_sync/cli.py
@@ -58,9 +58,21 @@ from .scim import get_account_client, sync
     is_flag=True,
     show_default=True,
     help="synchronizes all groups defined in `groups-json-file` instead of using graph api change feed")
+@click.option(
+    '--include-non-security-groups',
+    default=False,
+    is_flag=True,
+    show_default=True,
+    help="include non-security Entra groups in the sync")
+@click.option(
+    '--include-mail-enabled-groups',
+    default=False,
+    is_flag=True,
+    show_default=True,
+    help="include mail-enabled Entra groups in the sync")
 def sync_cli(groups_json_file, verbose, debug, dry_run_security_principals, dry_run_members, worker_threads,
              save_graph_response_json, query_graph_only, group_search_depth, full_sync,
-             graph_change_feed_grace_time):
+             graph_change_feed_grace_time, include_non_security_groups, include_mail_enabled_groups):
     install_logger()
 
     logger = logging.getLogger('sync')
@@ -71,7 +83,10 @@ def sync_cli(groups_json_file, verbose, debug, dry_run_security_principals, dry_
     if verbose:
         logger.setLevel(logging.DEBUG)
 
-    graph_client = GraphAPIClient()
+    graph_client = GraphAPIClient(
+        include_mail_enabled_groups=include_mail_enabled_groups,
+        include_non_security_groups=include_non_security_groups
+    )
     account_client = get_account_client()
 
     if groups_json_file:


### PR DESCRIPTION
Fixes #9. It's two flags rather than just one, but it gives a bit more flexbility.